### PR TITLE
3.7.1

### DIFF
--- a/src/Twino.Client.TMQ/Annotations/ChannelTopicAttribute.cs
+++ b/src/Twino.Client.TMQ/Annotations/ChannelTopicAttribute.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Twino.Client.TMQ.Annotations
+{
+    /// <summary>
+    /// Channel Topic attribute for queue messages.
+    /// Used for finding the channels by topics.
+    /// </summary>
+    public class ChannelTopicAttribute : Attribute
+    {
+        /// <summary>
+        /// The channel topic for the type
+        /// </summary>
+        public string Topic { get; }
+
+        /// <summary>
+        /// Creates new channel topic attribute
+        /// </summary>
+        public ChannelTopicAttribute(string topic)
+        {
+            Topic = topic;
+        }
+    }
+}

--- a/src/Twino.Client.TMQ/Annotations/Resolvers/TypeDeliveryDescriptor.cs
+++ b/src/Twino.Client.TMQ/Annotations/Resolvers/TypeDeliveryDescriptor.cs
@@ -42,6 +42,11 @@ namespace Twino.Client.TMQ.Annotations.Resolvers
         public string Tag { get; set; }
 
         /// <summary>
+        /// If channel is created with a message push and that value is not null, channel topic.
+        /// </summary>
+        public string Topic { get; set; }
+
+        /// <summary>
         /// Headers for delivery descriptor of type
         /// </summary>
         public List<KeyValuePair<string, string>> Headers { get; }
@@ -164,6 +169,9 @@ namespace Twino.Client.TMQ.Annotations.Resolvers
 
             if (!string.IsNullOrEmpty(Tag))
                 message.AddHeader(TmqHeaders.QUEUE_TAG, Tag);
+
+            if (!string.IsNullOrEmpty(Topic))
+                message.AddHeader(TmqHeaders.CHANNEL_TOPIC, Topic);
 
             foreach (KeyValuePair<string, string> pair in Headers)
                 message.AddHeader(pair.Key, pair.Value);

--- a/src/Twino.Client.TMQ/Annotations/Resolvers/TypeDeliveryResolver.cs
+++ b/src/Twino.Client.TMQ/Annotations/Resolvers/TypeDeliveryResolver.cs
@@ -129,6 +129,10 @@ namespace Twino.Client.TMQ.Annotations.Resolvers
             if (qta != null)
                 descriptor.Tag = qta.Tag;
 
+            ChannelTopicAttribute cta = type.GetCustomAttribute<ChannelTopicAttribute>(true);
+            if (cta != null)
+                descriptor.Topic = cta.Topic;
+
             IEnumerable<MessageHeaderAttribute> headerAttributes = type.GetCustomAttributes<MessageHeaderAttribute>(true);
             foreach (MessageHeaderAttribute headerAttribute in headerAttributes)
                 descriptor.Headers.Add(new KeyValuePair<string, string>(headerAttribute.Key, headerAttribute.Value));

--- a/src/Twino.Client.TMQ/Twino.Client.TMQ.csproj
+++ b/src/Twino.Client.TMQ/Twino.Client.TMQ.csproj
@@ -6,9 +6,9 @@
         <Product>Twino.Client.TMQ</Product>
         <Description>Twino Messaging Queue Client to connect all TMQ Servers</Description>
         <PackageTags>twino,tmq,client,mq,messaging,queue</PackageTags>
-        <AssemblyVersion>3.7.0</AssemblyVersion>
-        <FileVersion>3.7.0</FileVersion>
-        <PackageVersion>3.7.0</PackageVersion>
+        <AssemblyVersion>3.7.1</AssemblyVersion>
+        <FileVersion>3.7.1</FileVersion>
+        <PackageVersion>3.7.1</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/twino-framework/twino-mq</PackageProjectUrl>

--- a/src/Twino.MQ.Data/Twino.MQ.Data.csproj
+++ b/src/Twino.MQ.Data/Twino.MQ.Data.csproj
@@ -6,9 +6,9 @@
         <Product>Twino.MQ.Data</Product>
         <Description>Persistant queue message data library for Twino MQ</Description>
         <PackageTags>twino,server,messaging,queue,mq,persistent,database,db</PackageTags>
-        <AssemblyVersion>3.7.0</AssemblyVersion>
-        <FileVersion>3.7.0</FileVersion>
-        <PackageVersion>3.7.0</PackageVersion>
+        <AssemblyVersion>3.7.1</AssemblyVersion>
+        <FileVersion>3.7.1</FileVersion>
+        <PackageVersion>3.7.1</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/twino-framework/twino-mq</PackageProjectUrl>

--- a/src/Twino.MQ/Channel.cs
+++ b/src/Twino.MQ/Channel.cs
@@ -26,6 +26,11 @@ namespace Twino.MQ
         public string Name { get; }
 
         /// <summary>
+        /// Channel Topic
+        /// </summary>
+        public string Topic { get; set; }
+
+        /// <summary>
         /// Server of the channel
         /// </summary>
         public TwinoMQ Server { get; }

--- a/src/Twino.MQ/Network/ServerMessageHandler.cs
+++ b/src/Twino.MQ/Network/ServerMessageHandler.cs
@@ -169,6 +169,10 @@ namespace Twino.MQ.Network
                 return;
             }
 
+            string topic = message.FindHeader(TmqHeaders.CHANNEL_TOPIC);
+            if (!string.IsNullOrEmpty(topic))
+                channel.Topic = topic;
+
             ChannelClient found = channel.FindClient(client.UniqueId);
             if (found != null)
             {

--- a/src/Twino.MQ/Options/ChannelOptions.cs
+++ b/src/Twino.MQ/Options/ChannelOptions.cs
@@ -34,6 +34,11 @@ namespace Twino.MQ.Options
         public bool DestroyWhenEmpty { get; set; }
 
         /// <summary>
+        /// Channel Topic
+        /// </summary>
+        public string Topic { get; set; }
+
+        /// <summary>
         /// Clones channel options from another options
         /// </summary>
         internal static ChannelOptions CloneFrom(ChannelOptions options)
@@ -55,7 +60,8 @@ namespace Twino.MQ.Options
                 MessageSizeLimit = options.MessageSizeLimit,
                 ClientLimit = options.ClientLimit,
                 QueueLimit = options.QueueLimit,
-                DestroyWhenEmpty = options.DestroyWhenEmpty
+                DestroyWhenEmpty = options.DestroyWhenEmpty,
+                Topic = options.Topic
             };
         }
     }

--- a/src/Twino.MQ/Routing/DirectBinding.cs
+++ b/src/Twino.MQ/Routing/DirectBinding.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Twino.MQ.Clients;
 using Twino.Protocols.TMQ;
@@ -15,7 +16,7 @@ namespace Twino.MQ.Routing
     {
         private DateTime _clientListUpdateTime;
         private MqClient[] _clients;
-        private volatile int _roundRobinIndex = -1;
+        private int _roundRobinIndex = -1;
 
         /// <summary>
         /// Direct binding routing method
@@ -105,7 +106,7 @@ namespace Twino.MQ.Routing
 
         private Task<bool> SendRoundRobin(TmqMessage message)
         {
-            _roundRobinIndex++;
+            Interlocked.Increment(ref _roundRobinIndex);
             int i = _roundRobinIndex;
 
             if (i >= _clients.Length)

--- a/src/Twino.MQ/Routing/TagBinding.cs
+++ b/src/Twino.MQ/Routing/TagBinding.cs
@@ -107,9 +107,8 @@ namespace Twino.MQ.Routing
             if (_targetQueues.Length == 0)
                 return Task.FromResult(false);
 
-            ChannelQueue queue = _targetQueues[_roundRobinIndex];
-            TmqMessage msg = message.Clone(true, true, message.MessageId);
-            QueueMessage queueMessage = new QueueMessage(msg);
+            ChannelQueue queue = _targetQueues[i];
+            QueueMessage queueMessage = new QueueMessage(message);
             queue.AddMessage(queueMessage);
             return Task.FromResult(true);
         }
@@ -120,8 +119,7 @@ namespace Twino.MQ.Routing
                 return Task.FromResult(false);
 
             ChannelQueue queue = _targetQueues[0];
-            TmqMessage msg = message.Clone(true, true, message.MessageId);
-            QueueMessage queueMessage = new QueueMessage(msg);
+            QueueMessage queueMessage = new QueueMessage(message);
             queue.AddMessage(queueMessage);
             return Task.FromResult(true);
         }

--- a/src/Twino.MQ/Routing/TagBinding.cs
+++ b/src/Twino.MQ/Routing/TagBinding.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Twino.MQ.Clients;
 using Twino.MQ.Helpers;
@@ -18,8 +19,9 @@ namespace Twino.MQ.Routing
     {
         private ChannelQueue[] _targetQueues;
         private DateTime _queueUpdateTime;
-        private readonly TimeSpan _queueCacheDuration = TimeSpan.FromMilliseconds(1000);
+        private readonly TimeSpan _queueCacheDuration = TimeSpan.FromMilliseconds(250);
         private readonly IUniqueIdGenerator _idGenerator = new DefaultUniqueIdGenerator();
+        private int _roundRobinIndex = -1;
 
         /// <summary>
         /// Tag binding routing method
@@ -55,6 +57,24 @@ namespace Twino.MQ.Routing
             else if (Interaction == BindingInteraction.Response)
                 message.PendingResponse = true;
 
+            switch (RouteMethod)
+            {
+                case RouteMethod.Distribute:
+                    return SendDistribute(message);
+
+                case RouteMethod.OnlyFirst:
+                    return SendOnlyFirst(message);
+
+                case RouteMethod.RoundRobin:
+                    return SendRoundRobin(message);
+
+                default:
+                    return Task.FromResult(false);
+            }
+        }
+
+        private Task<bool> SendDistribute(TmqMessage message)
+        {
             bool sent = false;
             foreach (ChannelQueue queue in _targetQueues)
             {
@@ -71,6 +91,39 @@ namespace Twino.MQ.Routing
             }
 
             return Task.FromResult(sent);
+        }
+
+        private Task<bool> SendRoundRobin(TmqMessage message)
+        {
+            Interlocked.Increment(ref _roundRobinIndex);
+            int i = _roundRobinIndex;
+
+            if (i >= _targetQueues.Length)
+            {
+                _roundRobinIndex = 0;
+                i = 0;
+            }
+
+            if (_targetQueues.Length == 0)
+                return Task.FromResult(false);
+
+            ChannelQueue queue = _targetQueues[_roundRobinIndex];
+            TmqMessage msg = message.Clone(true, true, message.MessageId);
+            QueueMessage queueMessage = new QueueMessage(msg);
+            queue.AddMessage(queueMessage);
+            return Task.FromResult(true);
+        }
+
+        private Task<bool> SendOnlyFirst(TmqMessage message)
+        {
+            if (_targetQueues.Length < 1)
+                return Task.FromResult(false);
+
+            ChannelQueue queue = _targetQueues[0];
+            TmqMessage msg = message.Clone(true, true, message.MessageId);
+            QueueMessage queueMessage = new QueueMessage(msg);
+            queue.AddMessage(queueMessage);
+            return Task.FromResult(true);
         }
 
         private void RefreshQueueCache()

--- a/src/Twino.MQ/Routing/TopicBinding.cs
+++ b/src/Twino.MQ/Routing/TopicBinding.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Twino.MQ.Clients;
 using Twino.MQ.Helpers;
@@ -19,6 +20,7 @@ namespace Twino.MQ.Routing
         private DateTime _channelUpdateTime;
         private readonly TimeSpan _channelCacheDuration = TimeSpan.FromMilliseconds(250);
         private readonly IUniqueIdGenerator _idGenerator = new DefaultUniqueIdGenerator();
+        private int _roundRobinIndex = -1;
 
         /// <summary>
         /// Tag binding routing method
@@ -42,7 +44,7 @@ namespace Twino.MQ.Routing
         /// <summary>
         /// Sends the message to binding receivers
         /// </summary>
-        public override async Task<bool> Send(MqClient sender, TmqMessage message)
+        public override Task<bool> Send(MqClient sender, TmqMessage message)
         {
             if (DateTime.UtcNow - _channelUpdateTime > _channelCacheDuration)
                 RefreshChannelCache();
@@ -54,6 +56,24 @@ namespace Twino.MQ.Routing
             else if (Interaction == BindingInteraction.Response)
                 message.PendingResponse = true;
 
+            switch (RouteMethod)
+            {
+                case RouteMethod.Distribute:
+                    return SendDistribute(message);
+
+                case RouteMethod.OnlyFirst:
+                    return SendOnlyFirst(message);
+
+                case RouteMethod.RoundRobin:
+                    return SendRoundRobin(message);
+
+                default:
+                    return Task.FromResult(false);
+            }
+        }
+
+        private async Task<bool> SendDistribute(TmqMessage message)
+        {
             ushort queueId = ContentType.HasValue ? ContentType.Value : message.ContentType;
             bool sent = false;
             foreach (Channel channel in _channels)
@@ -80,6 +100,59 @@ namespace Twino.MQ.Routing
             }
 
             return sent;
+        }
+
+        private async Task<bool> SendRoundRobin(TmqMessage message)
+        {
+            Interlocked.Increment(ref _roundRobinIndex);
+            int i = _roundRobinIndex;
+
+            if (i >= _channels.Length)
+            {
+                _roundRobinIndex = 0;
+                i = 0;
+            }
+
+            if (_channels.Length == 0)
+                return false;
+
+            Channel channel = _channels[i];
+
+            ushort queueId = ContentType.HasValue ? ContentType.Value : message.ContentType;
+            ChannelQueue queue = channel.FindQueue(queueId);
+            if (queue == null)
+            {
+                if (!Router.Server.Options.AutoQueueCreation)
+                    return false;
+
+                queue = await channel.CreateQueue(queueId, channel.Options, message, Router.Server.DeliveryHandlerFactory);
+            }
+
+            QueueMessage queueMessage = new QueueMessage(message);
+            queue.AddMessage(queueMessage);
+            return true;
+        }
+
+        private async Task<bool> SendOnlyFirst(TmqMessage message)
+        {
+            if (_channels.Length < 1)
+                return false;
+
+            Channel channel = _channels[0];
+
+            ushort queueId = ContentType.HasValue ? ContentType.Value : message.ContentType;
+            ChannelQueue queue = channel.FindQueue(queueId);
+            if (queue == null)
+            {
+                if (!Router.Server.Options.AutoQueueCreation)
+                    return false;
+
+                queue = await channel.CreateQueue(queueId, channel.Options, message, Router.Server.DeliveryHandlerFactory);
+            }
+
+            QueueMessage queueMessage = new QueueMessage(message);
+            queue.AddMessage(queueMessage);
+            return true;
         }
 
         private void RefreshChannelCache()

--- a/src/Twino.MQ/Routing/TopicBinding.cs
+++ b/src/Twino.MQ/Routing/TopicBinding.cs
@@ -17,7 +17,7 @@ namespace Twino.MQ.Routing
     {
         private Channel[] _channels;
         private DateTime _channelUpdateTime;
-        private readonly TimeSpan _channelCacheDuration = TimeSpan.FromMilliseconds(1000);
+        private readonly TimeSpan _channelCacheDuration = TimeSpan.FromMilliseconds(250);
         private readonly IUniqueIdGenerator _idGenerator = new DefaultUniqueIdGenerator();
 
         /// <summary>

--- a/src/Twino.MQ/Twino.MQ.csproj
+++ b/src/Twino.MQ/Twino.MQ.csproj
@@ -6,9 +6,9 @@
         <Product>Twino.MQ</Product>
         <Description>Messaging Queue Server library with TMQ Protocol via Twino Server</Description>
         <PackageTags>twino,server,tmq,messaging,queue,mq</PackageTags>
-        <AssemblyVersion>3.7.0</AssemblyVersion>
-        <FileVersion>3.7.0</FileVersion>
-        <PackageVersion>3.7.0</PackageVersion>
+        <AssemblyVersion>3.7.1</AssemblyVersion>
+        <FileVersion>3.7.1</FileVersion>
+        <PackageVersion>3.7.1</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/twino-framework/twino-mq</PackageProjectUrl>

--- a/src/Twino.MQ/TwinoMQ.cs
+++ b/src/Twino.MQ/TwinoMQ.cs
@@ -225,6 +225,7 @@ namespace Twino.MQ
                 throw new DuplicateNameException("There is already a channel with same name: " + name);
 
             channel = new Channel(this, options, name);
+            channel.Topic = options.Topic;
             _channels.Add(channel);
 
             if (ChannelEventHandler != null)

--- a/src/Twino.Protocols.TMQ/TmqHeaders.cs
+++ b/src/Twino.Protocols.TMQ/TmqHeaders.cs
@@ -159,46 +159,50 @@ namespace Twino.Protocols.TMQ
         /// "LIFO"
         /// </summary>
         public const string LIFO = "LIFO";
-        
+
         /// <summary>
         /// "Priority-Messages"
         /// </summary>
         public const string PRIORITY_MESSAGES = "Priority-Messages";
-        
+
         /// <summary>
         /// "Messages"
         /// </summary>
         public const string MESSAGES = "Messages";
-        
+
         /// <summary>
         /// "Delivery-Handler"
         /// </summary>
         public const string DELIVERY_HANDLER = "Delivery-Handler";
-        
+
         /// <summary>
         /// "Wait-For-Acknowledge"
         /// </summary>
         public const string WAIT_FOR_ACKNOWLEDGE = "Wait-For-Acknowledge";
-        
+
         /// <summary>
         /// "Queue-Status"
         /// </summary>
         public const string QUEUE_STATUS = "Queue-Status";
-        
+
         /// <summary>
         /// "Queue-Tag"
         /// </summary>
         public const string QUEUE_TAG = "Queue-Tag";
-        
+
         /// <summary>
         /// "Route-Method"
         /// </summary>
         public const string ROUTE_METHOD = "Route-Method";
-        
+
         /// <summary>
         /// "Binding-Name"
         /// </summary>
         public const string BINDING_NAME = "Binding-Name";
 
+        /// <summary>
+        /// "Channel-Topic"
+        /// </summary>
+        public const string CHANNEL_TOPIC = "Channel-Topic";
     }
 }

--- a/src/Twino.Protocols.TMQ/Twino.Protocols.TMQ.csproj
+++ b/src/Twino.Protocols.TMQ/Twino.Protocols.TMQ.csproj
@@ -6,9 +6,9 @@
         <Product>Twino.Protocols.TMQ</Product>
         <Description>Twino Messaging Queue (TMQ) Protocol library and server extension for Twino Server</Description>
         <PackageTags>twino,tcp,server,http,messaging,queue,tmq,mq,protocol</PackageTags>
-        <AssemblyVersion>3.7.0</AssemblyVersion>
-        <FileVersion>3.7.0</FileVersion>
-        <PackageVersion>3.7.0</PackageVersion>
+        <AssemblyVersion>3.7.1</AssemblyVersion>
+        <FileVersion>3.7.1</FileVersion>
+        <PackageVersion>3.7.1</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/twino-framework/twino-mq</PackageProjectUrl>


### PR DESCRIPTION
- ChannelTopicAttribute is added. It works similar to Queue Tag attribute. Sets the topic value of the channel on create or join.
- TopicBinding is added to router bindings. Routers can route messages to channel queues by topic. Target can include asterisk for filtering.
- Route Method fixed on TagBinding and TopicBinding