### PR TITLE
4.0.6

### DIFF
--- a/src/Twino.Client.TMQ/Twino.Client.TMQ.csproj
+++ b/src/Twino.Client.TMQ/Twino.Client.TMQ.csproj
@@ -6,9 +6,9 @@
         <Product>Twino.Client.TMQ</Product>
         <Description>Twino Messaging Queue Client to connect all TMQ Servers</Description>
         <PackageTags>twino,tmq,client,mq,messaging,queue</PackageTags>
-        <AssemblyVersion>4.0.5</AssemblyVersion>
-        <FileVersion>4.0.5</FileVersion>
-        <PackageVersion>4.0.5</PackageVersion>
+        <AssemblyVersion>4.0.6</AssemblyVersion>
+        <FileVersion>4.0.6</FileVersion>
+        <PackageVersion>4.0.6</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/twino-framework/twino-mq</PackageProjectUrl>

--- a/src/Twino.MQ.Data/PersistentDeliveryHandler.cs
+++ b/src/Twino.MQ.Data/PersistentDeliveryHandler.cs
@@ -39,6 +39,19 @@ namespace Twino.MQ.Data
         /// </summary>
         public async Task Initialize()
         {
+            if (Queue.Options.Acknowledge == QueueAckDecision.None)
+            {
+                if (DeleteWhen == DeleteWhen.AfterAcknowledgeReceived)
+                    throw new NotSupportedException("Delete option is AfterAcknowledgeReceived but queue Acknowledge option is None. " +
+                                                    "Messages are not deleted from disk with this configuration. " +
+                                                    "Please change queue Acknowledge option or DeleteWhen option");
+
+                if (ProducerAckDecision == ProducerAckDecision.AfterConsumerAckReceived)
+                    throw new NotSupportedException("Producer Ack option is AfterConsumerAckReceived but queue Acknowledge option is None. " +
+                                                    "Messages are not deleted from disk with this configuration. " +
+                                                    "Please change queue Acknowledge option or ProducerAckDecision option");
+            }
+
             await Database.Open();
             Queue.OnDestroyed += Destroy;
 

--- a/src/Twino.MQ.Data/Twino.MQ.Data.csproj
+++ b/src/Twino.MQ.Data/Twino.MQ.Data.csproj
@@ -6,9 +6,9 @@
         <Product>Twino.MQ.Data</Product>
         <Description>Persistant queue message data library for Twino MQ</Description>
         <PackageTags>twino,server,messaging,queue,mq,persistent,database,db</PackageTags>
-        <AssemblyVersion>4.0.5</AssemblyVersion>
-        <FileVersion>4.0.5</FileVersion>
-        <PackageVersion>4.0.5</PackageVersion>
+        <AssemblyVersion>4.0.6</AssemblyVersion>
+        <FileVersion>4.0.6</FileVersion>
+        <PackageVersion>4.0.6</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/twino-framework/twino-mq</PackageProjectUrl>

--- a/src/Twino.MQ/IErrorHandler.cs
+++ b/src/Twino.MQ/IErrorHandler.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Twino.MQ
+{
+    /// <summary>
+    /// Exception implementations for Twino MQ
+    /// </summary>
+    public interface IErrorHandler
+    {
+        /// <summary>
+        /// Executed when an exception is thrown by the server
+        /// </summary>
+        /// <param name="hint">Error hint</param>
+        /// <param name="exception">Exception</param>
+        /// <param name="payload">Extra data about the error</param>
+        void Error(string hint, Exception exception, string payload);
+    }
+}

--- a/src/Twino.MQ/NodeManager.cs
+++ b/src/Twino.MQ/NodeManager.cs
@@ -176,7 +176,6 @@ namespace Twino.MQ
 
         #endregion
 
-
         /// <summary>
         /// Sends a message to connected master nodes
         /// </summary>

--- a/src/Twino.MQ/Queues/States/BroadcastQueueState.cs
+++ b/src/Twino.MQ/Queues/States/BroadcastQueueState.cs
@@ -31,10 +31,18 @@ namespace Twino.MQ.Queues.States
 
         public async Task<PushResult> Push(QueueMessage message)
         {
-            ProcessingMessage = message;
-            PushResult result = await ProcessMessage(message);
-            ProcessingMessage = null;
-            return result;
+            try
+            {
+                ProcessingMessage = message;
+                PushResult result = await ProcessMessage(message);
+                ProcessingMessage = null;
+                return result;
+            }
+            catch (Exception e)
+            {
+                _queue.Server.SendError("PUSH", e, $"QueueName:{_queue.Name}, State:Broadcast");
+                return PushResult.Error;
+            }
         }
 
         private async Task<PushResult> ProcessMessage(QueueMessage message)

--- a/src/Twino.MQ/Queues/States/PushQueueState.cs
+++ b/src/Twino.MQ/Queues/States/PushQueueState.cs
@@ -36,10 +36,18 @@ namespace Twino.MQ.Queues.States
 
         public async Task<PushResult> Push(QueueMessage message)
         {
-            ProcessingMessage = message;
-            PushResult result = await ProcessMessage(message);
-            ProcessingMessage = null;
-            return result;
+            try
+            {
+                ProcessingMessage = message;
+                PushResult result = await ProcessMessage(message);
+                ProcessingMessage = null;
+                return result;
+            }
+            catch (Exception e)
+            {
+                _queue.Server.SendError("PUSH", e, $"QueueName:{_queue.Name}, State:Push");
+                return PushResult.Error;
+            }
         }
 
         private async Task<PushResult> ProcessMessage(QueueMessage message)

--- a/src/Twino.MQ/Twino.MQ.csproj
+++ b/src/Twino.MQ/Twino.MQ.csproj
@@ -6,9 +6,9 @@
         <Product>Twino.MQ</Product>
         <Description>Messaging Queue Server library with TMQ Protocol via Twino Server</Description>
         <PackageTags>twino,server,tmq,messaging,queue,mq</PackageTags>
-        <AssemblyVersion>4.0.5</AssemblyVersion>
-        <FileVersion>4.0.5</FileVersion>
-        <PackageVersion>4.0.5</PackageVersion>
+        <AssemblyVersion>4.0.6</AssemblyVersion>
+        <FileVersion>4.0.6</FileVersion>
+        <PackageVersion>4.0.6</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/twino-framework/twino-mq</PackageProjectUrl>

--- a/src/Twino.Protocols.TMQ/Twino.Protocols.TMQ.csproj
+++ b/src/Twino.Protocols.TMQ/Twino.Protocols.TMQ.csproj
@@ -6,9 +6,9 @@
         <Product>Twino.Protocols.TMQ</Product>
         <Description>Twino Messaging Queue (TMQ) Protocol library and server extension for Twino Server</Description>
         <PackageTags>twino,tcp,server,http,messaging,queue,tmq,mq,protocol</PackageTags>
-        <AssemblyVersion>4.0.5</AssemblyVersion>
-        <FileVersion>4.0.5</FileVersion>
-        <PackageVersion>4.0.5</PackageVersion>
+        <AssemblyVersion>4.0.6</AssemblyVersion>
+        <FileVersion>4.0.6</FileVersion>
+        <PackageVersion>4.0.6</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/twino-framework/twino-mq</PackageProjectUrl>


### PR DESCRIPTION
- Using "delete message after acknowledge in persistent delivery handler" with "none acknowledge queue option" was not working properly. That usage now throws an exception on queue initialization.
- IErrorHandler implementation is added to Twino MQ. All exceptions in messaging queue server, routers, bindings and queues can be handled with this interface.