### PR TITLE
4.2.1

### DIFF
--- a/src/Samples/RoutingSample.DirectConsumer/BaseDirectConsumer.cs
+++ b/src/Samples/RoutingSample.DirectConsumer/BaseDirectConsumer.cs
@@ -7,7 +7,7 @@ namespace RoutingSample.DirectConsumer
 {
 	[AutoAck]
 	[AutoNack(NackReason.ExceptionType)]
-	[PushExceptions("SAMPLE-EXCEPTION-QUEUE")]
+	//[PushExceptions("SAMPLE-EXCEPTION-QUEUE")]
 	public abstract class BaseDirectConsumer<T> : IDirectConsumer<T>
 	{
 		protected abstract Task Handle(T model);

--- a/src/Samples/Sample.Consumer/Program.cs
+++ b/src/Samples/Sample.Consumer/Program.cs
@@ -26,7 +26,6 @@ namespace Sample.Consumer
                    .ConfigureModels(cfg => cfg.UseQueueName(type => type.Name)
                                               .UseConsumerAck()
                                               .AddMessageHeader("Sender-Client-Name", "MyName")
-                                              .PublishConsumerExceptions("router-name")
                                               .SetPutBackDelay(TimeSpan.FromSeconds(10)));
 
 

--- a/src/Tests/Test.Bus/Consumers/ExceptionConsumer1.cs
+++ b/src/Tests/Test.Bus/Consumers/ExceptionConsumer1.cs
@@ -1,12 +1,12 @@
 using System.Threading.Tasks;
+using Test.Bus.Models;
 using Twino.MQ.Client;
 using Twino.MQ.Client.Annotations;
 using Twino.Protocols.TMQ;
 
 namespace Test.Bus.Consumers
 {
-    [QueueName("ex-queue-1")]
-    public class ExceptionConsumer1 : IQueueConsumer<string>
+    public class ExceptionConsumer1 : IQueueConsumer<ExceptionModel1>
     {
         public int Count { get; private set; }
 
@@ -17,7 +17,7 @@ namespace Test.Bus.Consumers
             Instance = this;
         }
 
-        public Task Consume(TwinoMessage message, string model, TmqClient client)
+        public Task Consume(TwinoMessage message, ExceptionModel1 model, TmqClient client)
         {
             Count++;
             return Task.CompletedTask;

--- a/src/Tests/Test.Bus/Consumers/ExceptionConsumer2.cs
+++ b/src/Tests/Test.Bus/Consumers/ExceptionConsumer2.cs
@@ -1,12 +1,12 @@
 using System.Threading.Tasks;
+using Test.Bus.Models;
 using Twino.MQ.Client;
 using Twino.MQ.Client.Annotations;
 using Twino.Protocols.TMQ;
 
 namespace Test.Bus.Consumers
 {
-    [QueueName("ex-queue-2")]
-    public class ExceptionConsumer2 : IQueueConsumer<string>
+    public class ExceptionConsumer2 : IQueueConsumer<ExceptionModel2>
     {
         public int Count { get; private set; }
 
@@ -17,7 +17,7 @@ namespace Test.Bus.Consumers
             Instance = this;
         }
 
-        public Task Consume(TwinoMessage message, string model, TmqClient client)
+        public Task Consume(TwinoMessage message, ExceptionModel2 model, TmqClient client)
         {
             Count++;
             return Task.CompletedTask;

--- a/src/Tests/Test.Bus/Consumers/ExceptionConsumer3.cs
+++ b/src/Tests/Test.Bus/Consumers/ExceptionConsumer3.cs
@@ -1,12 +1,12 @@
 using System.Threading.Tasks;
+using Test.Bus.Models;
 using Twino.MQ.Client;
 using Twino.MQ.Client.Annotations;
 using Twino.Protocols.TMQ;
 
 namespace Test.Bus.Consumers
 {
-    [QueueName("ex-queue-3")]
-    public class ExceptionConsumer3 : IQueueConsumer<string>
+    public class ExceptionConsumer3 : IQueueConsumer<ExceptionModel3>
     {
         public int Count { get; private set; }
 
@@ -17,7 +17,7 @@ namespace Test.Bus.Consumers
             Instance = this;
         }
 
-        public Task Consume(TwinoMessage message, string model, TmqClient client)
+        public Task Consume(TwinoMessage message, ExceptionModel3 model, TmqClient client)
         {
             Count++;
             return Task.CompletedTask;

--- a/src/Tests/Test.Bus/Consumers/QueueConsumer3.cs
+++ b/src/Tests/Test.Bus/Consumers/QueueConsumer3.cs
@@ -9,9 +9,9 @@ namespace Test.Bus.Consumers
 {
     [AutoAck]
     [AutoNack]
-    [PushExceptions("ex-queue-1")]
-    [PushExceptions(typeof(NotSupportedException), "ex-queue-2")]
-    [PushExceptions(typeof(InvalidOperationException), "ex-queue-3")]
+    [PushExceptions(typeof(ExceptionModel1))]
+    [PushExceptions(typeof(ExceptionModel2), typeof(NotSupportedException))]
+    [PushExceptions(typeof(ExceptionModel3), typeof(InvalidOperationException))]
     public class QueueConsumer3 : IQueueConsumer<Model3>
     {
         public int Count { get; private set; }

--- a/src/Tests/Test.Bus/Consumers/QueueConsumer4.cs
+++ b/src/Tests/Test.Bus/Consumers/QueueConsumer4.cs
@@ -9,9 +9,9 @@ namespace Test.Bus.Consumers
 {
     [AutoAck]
     [AutoNack]
-    [PublishExceptions("ex-route-1")]
-    [PublishExceptions(typeof(NotSupportedException), "ex-route-2")]
-    [PublishExceptions(typeof(InvalidOperationException), "ex-route-3")]
+    [PublishExceptions(typeof(ExceptionModel1))]
+    [PublishExceptions(typeof(ExceptionModel2), typeof(NotSupportedException))]
+    [PublishExceptions(typeof(ExceptionModel3), typeof(InvalidOperationException))]
     public class QueueConsumer4 : IQueueConsumer<Model4>
     {
         public int Count { get; private set; }

--- a/src/Tests/Test.Bus/Models/ExceptionModel1.cs
+++ b/src/Tests/Test.Bus/Models/ExceptionModel1.cs
@@ -1,0 +1,14 @@
+using Twino.MQ.Client.Annotations;
+using Twino.MQ.Client.Models;
+
+namespace Test.Bus.Models
+{
+    [QueueName("ex-queue-1")]
+    [RouterName("ex-route-1")]
+    public class ExceptionModel1 : ITransportableException
+    {
+        public void Initialize(ExceptionContext context)
+        {
+        }
+    }
+}

--- a/src/Tests/Test.Bus/Models/ExceptionModel2.cs
+++ b/src/Tests/Test.Bus/Models/ExceptionModel2.cs
@@ -1,0 +1,14 @@
+using Twino.MQ.Client.Annotations;
+using Twino.MQ.Client.Models;
+
+namespace Test.Bus.Models
+{
+    [QueueName("ex-queue-2")]
+    [RouterName("ex-route-2")]
+    public class ExceptionModel2 : ITransportableException
+    {
+        public void Initialize(ExceptionContext context)
+        {
+        }
+    }
+}

--- a/src/Tests/Test.Bus/Models/ExceptionModel3.cs
+++ b/src/Tests/Test.Bus/Models/ExceptionModel3.cs
@@ -1,0 +1,14 @@
+using Twino.MQ.Client.Annotations;
+using Twino.MQ.Client.Models;
+
+namespace Test.Bus.Models
+{
+    [QueueName("ex-queue-3")]
+    [RouterName("ex-route-3")]
+    public class ExceptionModel3 : ITransportableException
+    {
+        public void Initialize(ExceptionContext context)
+        {
+        }
+    }
+}

--- a/src/Tests/Test.Bus/Models/Model4.cs
+++ b/src/Tests/Test.Bus/Models/Model4.cs
@@ -5,7 +5,7 @@ using Twino.Protocols.TMQ;
 namespace Test.Bus.Models
 {
     [HighPriorityMessage]
-    [MessageHeader("X*Model", "4")]
+    [MessageHeader("X-Model", "4")]
     [QueueStatus(MessagingQueueStatus.Push)]
     [Acknowledge(QueueAckDecision.WaitForAcknowledge)]
     public class Model4

--- a/src/Twino.MQ.Bus/Twino.MQ.Bus.csproj
+++ b/src/Twino.MQ.Bus/Twino.MQ.Bus.csproj
@@ -6,9 +6,9 @@
         <Product>Twino.MQ.Bus</Product>
         <Description>Twino MQ Bus extension for Twino IOC</Description>
         <PackageTags>twino,tmq,consumer,bus</PackageTags>
-        <AssemblyVersion>4.2.0</AssemblyVersion>
-        <FileVersion>4.2.0</FileVersion>
-        <PackageVersion>4.2.0</PackageVersion>
+        <AssemblyVersion>4.2.1</AssemblyVersion>
+        <FileVersion>4.2.1</FileVersion>
+        <PackageVersion>4.2.1</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/twino-framework/twino-extensions</PackageProjectUrl>

--- a/src/Twino.MQ.Client/Annotations/PublishExceptionsAttribute.cs
+++ b/src/Twino.MQ.Client/Annotations/PublishExceptionsAttribute.cs
@@ -12,34 +12,27 @@ namespace Twino.MQ.Client.Annotations
         /// Exception type
         /// </summary>
         public Type ExceptionType { get; }
-        
+
         /// <summary>
-        /// Router name
+        /// Exception model type
         /// </summary>
-        public string RouterName { get; }
-        
-        /// <summary>
-        /// Content Type
-        /// </summary>
-        public ushort ContentType { get; }
+        public Type ModelType { get; }
 
         /// <summary>
         /// Publishes all exceptions
         /// </summary>
-        public PublishExceptionsAttribute(string routerName, ushort contentType = 0)
+        public PublishExceptionsAttribute(Type modelType)
         {
-            RouterName = routerName;
-            ContentType = contentType;
+            ModelType = modelType;
         }
 
         /// <summary>
         /// Publishes specified type of exceptions
         /// </summary>
-        public PublishExceptionsAttribute(Type exceptionType, string routerName, ushort contentType = 0)
+        public PublishExceptionsAttribute(Type modelType, Type exceptionType)
         {
+            ModelType = modelType;
             ExceptionType = exceptionType;
-            RouterName = routerName;
-            ContentType = contentType;
         }
     }
 }

--- a/src/Twino.MQ.Client/Annotations/PushExceptionsAttribute.cs
+++ b/src/Twino.MQ.Client/Annotations/PushExceptionsAttribute.cs
@@ -14,25 +14,25 @@ namespace Twino.MQ.Client.Annotations
         public Type ExceptionType { get; }
         
         /// <summary>
-        /// Queue name
+        /// Exception model type
         /// </summary>
-        public string QueueName { get; }
+        public Type ModelType { get; }
         
         /// <summary>
         /// Pushes all exceptions
         /// </summary>
-        public PushExceptionsAttribute(string queue)
+        public PushExceptionsAttribute(Type modelType)
         {
-            QueueName = queue;
+            ModelType = modelType;
         }
 
         /// <summary>
         /// Pushes specified type of exceptions
         /// </summary>
-        public PushExceptionsAttribute(Type exceptionType, string queue)
+        public PushExceptionsAttribute(Type modelType, Type exceptionType)
         {
+            ModelType = modelType;
             ExceptionType = exceptionType;
-            QueueName = queue;
         }
     }
 }

--- a/src/Twino.MQ.Client/Internal/DirectConsumerExecuter.cs
+++ b/src/Twino.MQ.Client/Internal/DirectConsumerExecuter.cs
@@ -54,7 +54,7 @@ namespace Twino.MQ.Client.Internal
                 if (SendNack)
                     await SendNegativeAck(message, client, e);
 
-                await SendExceptions(client, e);
+                await SendExceptions(message, client, e);
                 exception = e;
             }
             finally

--- a/src/Twino.MQ.Client/Internal/QueueConsumerExecuter.cs
+++ b/src/Twino.MQ.Client/Internal/QueueConsumerExecuter.cs
@@ -34,6 +34,7 @@ namespace Twino.MQ.Client.Internal
             {
                 if (_consumer != null)
                     await Consume(_consumer, message, t, client);
+                
                 else if (_consumerFactoryCreator != null)
                 {
                     consumerFactory = _consumerFactoryCreator();
@@ -52,7 +53,7 @@ namespace Twino.MQ.Client.Internal
                 if (SendNack)
                     await SendNegativeAck(message, client, e);
 
-                await SendExceptions(client, e);
+                await SendExceptions(message, client, e);
                 exception = e;
             }
             finally

--- a/src/Twino.MQ.Client/Internal/RequestHandlerExecuter.cs
+++ b/src/Twino.MQ.Client/Internal/RequestHandlerExecuter.cs
@@ -89,7 +89,7 @@ namespace Twino.MQ.Client.Internal
                     }
                 }
 
-                await SendExceptions(client, e);
+                await SendExceptions(message, client, e);
                 exception = e;
             }
             finally

--- a/src/Twino.MQ.Client/ModelTypeConfigurator.cs
+++ b/src/Twino.MQ.Client/ModelTypeConfigurator.cs
@@ -16,7 +16,7 @@ namespace Twino.MQ.Client
 
         internal List<Func<KeyValuePair<string, string>>> HeaderFactories { get; } = new List<Func<KeyValuePair<string, string>>>();
         internal Func<Type, string> QueueNameFactory { get; private set; }
-        
+
         internal MessagingQueueStatus? QueueStatus { get; private set; }
         internal QueueAckDecision? AckDecision { get; private set; }
         internal int? DelayBetweenMessages { get; private set; }
@@ -33,11 +33,11 @@ namespace Twino.MQ.Client
 
         internal RetryAttribute Retry { get; private set; }
 
-        internal string DefaultPushException { get; private set; }
-        internal List<Tuple<Type, string>> PushExceptions { get; } = new List<Tuple<Type, string>>();
+        internal TransportExceptionDescriptor DefaultPushException { get; private set; }
+        internal List<TransportExceptionDescriptor> PushExceptions { get; } = new List<TransportExceptionDescriptor>();
 
-        internal KeyValuePair<string, ushort> DefaultPublishException { get; private set; }
-        internal List<Tuple<Type, KeyValuePair<string, ushort>>> PublishExceptions { get; } = new List<Tuple<Type, KeyValuePair<string, ushort>>>();
+        internal TransportExceptionDescriptor DefaultPublishException { get; private set; }
+        internal List<TransportExceptionDescriptor> PublishExceptions { get; } = new List<TransportExceptionDescriptor>();
 
         #endregion
 
@@ -163,36 +163,40 @@ namespace Twino.MQ.Client
         /// <summary>
         /// Push exceptions in consumers' consume operations to specified queue
         /// </summary>
-        public ModelTypeConfigurator PushConsumerExceptions(string queueName)
+        public ModelTypeConfigurator PushConsumerExceptions<TModel>()
+            where TModel : ITransportableException, new()
         {
-            DefaultPushException = queueName;
+            DefaultPushException = new TransportExceptionDescriptor(typeof(TModel));
             return this;
         }
 
         /// <summary>
         /// Push exceptions in specified types in consumers' consume operations to specified queue
         /// </summary>
-        public ModelTypeConfigurator PushConsumerExceptions(Type exceptionType, string queueName)
+        public ModelTypeConfigurator PushConsumerExceptions<TModel>(Type exceptionType)
+            where TModel : ITransportableException, new()
         {
-            PushExceptions.Add(new Tuple<Type, string>(exceptionType, queueName));
+            PushExceptions.Add(new TransportExceptionDescriptor(typeof(TModel), exceptionType));
             return this;
         }
 
         /// <summary>
         /// Publish exceptions in consumers' consume operations to specified route
         /// </summary>
-        public ModelTypeConfigurator PublishConsumerExceptions(string routerName, ushort contentType = 0)
+        public ModelTypeConfigurator PublishConsumerExceptions<TModel>()
+            where TModel : ITransportableException, new()
         {
-            DefaultPublishException = new KeyValuePair<string, ushort>(routerName, contentType);
+            DefaultPublishException = new TransportExceptionDescriptor(typeof(TModel));
             return this;
         }
 
         /// <summary>
         /// Publish exceptions in specified types in consumers' consume operations to specified route
         /// </summary>
-        public ModelTypeConfigurator PublishConsumerExceptions(Type exceptionType, string routerName, ushort contentType = 0)
+        public ModelTypeConfigurator PublishConsumerExceptions<TModel>(Type exceptionType)
+            where TModel : ITransportableException, new()
         {
-            PublishExceptions.Add(new Tuple<Type, KeyValuePair<string, ushort>>(exceptionType, new KeyValuePair<string, ushort>(routerName, contentType)));
+            PublishExceptions.Add(DefaultPublishException = new TransportExceptionDescriptor(typeof(TModel), exceptionType));
             return this;
         }
 

--- a/src/Twino.MQ.Client/Models/ExceptionContext.cs
+++ b/src/Twino.MQ.Client/Models/ExceptionContext.cs
@@ -1,0 +1,26 @@
+using System;
+using Twino.Protocols.TMQ;
+
+namespace Twino.MQ.Client.Models
+{
+    /// <summary>
+    /// Used when an exception is ready to push or publish
+    /// </summary>
+    public class ExceptionContext
+    {
+        /// <summary>
+        /// Consumer object
+        /// </summary>
+        public object Consumer { get; set; }
+        
+        /// <summary>
+        /// The consuming message when exception is thrown
+        /// </summary>
+        public TwinoMessage ConsumingMessage { get; set; }
+        
+        /// <summary>
+        /// Exception object
+        /// </summary>
+        public Exception Exception { get; set; }
+    }
+}

--- a/src/Twino.MQ.Client/Models/ITransportableException.cs
+++ b/src/Twino.MQ.Client/Models/ITransportableException.cs
@@ -1,0 +1,14 @@
+namespace Twino.MQ.Client.Models
+{
+    /// <summary>
+    /// In order to use models on PushException or PublishException, they must implement that interface.
+    /// The model will be pushed or published after Initialize method is called.
+    /// </summary>
+    public interface ITransportableException
+    {
+        /// <summary>
+        /// Initializes transportable exception model
+        /// </summary>
+        void Initialize(ExceptionContext context);
+    }
+}

--- a/src/Twino.MQ.Client/Models/TransportExceptionDescriptor.cs
+++ b/src/Twino.MQ.Client/Models/TransportExceptionDescriptor.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Twino.MQ.Client.Models
+{
+    internal class TransportExceptionDescriptor
+    {
+        public Type ModelType { get; set; }
+        public Type ExceptionType { get; set; }
+
+        public TransportExceptionDescriptor(Type modelType)
+        {
+            ModelType = modelType;
+        }
+
+        public TransportExceptionDescriptor(Type modelType, Type exceptionType)
+        {
+            ModelType = modelType;
+            ExceptionType = exceptionType;
+        }
+    }
+}

--- a/src/Twino.MQ.Client/Twino.MQ.Client.csproj
+++ b/src/Twino.MQ.Client/Twino.MQ.Client.csproj
@@ -6,9 +6,9 @@
         <Product>Twino.MQ.Client</Product>
         <Description>Twino Messaging Queue Client to connect all TMQ Servers</Description>
         <PackageTags>twino,tmq,client,mq,messaging,queue</PackageTags>
-        <AssemblyVersion>4.2.0</AssemblyVersion>
-        <FileVersion>4.2.0</FileVersion>
-        <PackageVersion>4.2.0</PackageVersion>
+        <AssemblyVersion>4.2.1</AssemblyVersion>
+        <FileVersion>4.2.1</FileVersion>
+        <PackageVersion>4.2.1</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/twino-framework/twino-mq</PackageProjectUrl>

--- a/src/Twino.MQ.Data/Twino.MQ.Data.csproj
+++ b/src/Twino.MQ.Data/Twino.MQ.Data.csproj
@@ -6,9 +6,9 @@
         <Product>Twino.MQ.Data</Product>
         <Description>Persistant queue message data library for Twino MQ</Description>
         <PackageTags>twino,server,messaging,queue,mq,persistent,database,db</PackageTags>
-        <AssemblyVersion>4.2.0</AssemblyVersion>
-        <FileVersion>4.2.0</FileVersion>
-        <PackageVersion>4.2.0</PackageVersion>
+        <AssemblyVersion>4.2.1</AssemblyVersion>
+        <FileVersion>4.2.1</FileVersion>
+        <PackageVersion>4.2.1</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/twino-framework/twino-mq</PackageProjectUrl>

--- a/src/Twino.MQ.WebSocket.Server/Twino.MQ.WebSocket.Server.csproj
+++ b/src/Twino.MQ.WebSocket.Server/Twino.MQ.WebSocket.Server.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Twino.Protocols.Http" Version="4.0.2" />
-      <PackageReference Include="Twino.Protocols.WebSocket" Version="4.0.7" />
+      <PackageReference Include="Twino.Protocols.Http" Version="4.2.1" />
+      <PackageReference Include="Twino.Protocols.WebSocket" Version="4.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Twino.MQ/MqExtensions.cs
+++ b/src/Twino.MQ/MqExtensions.cs
@@ -277,7 +277,16 @@ namespace Twino.MQ
         /// <summary>
         /// Uses a custom server message handler
         /// </summary>
+        [Obsolete("This method adds new handler, use AddServerMessageHandler instead")]
         public static TwinoMqBuilder UseServerMessageHandler(this TwinoMqBuilder builder, IServerMessageHandler messageHandler)
+        {
+            return AddServerMessageHandler(builder, messageHandler);
+        }
+        
+        /// <summary>
+        /// Uses a custom server message handler
+        /// </summary>
+        public static TwinoMqBuilder AddServerMessageHandler(this TwinoMqBuilder builder, IServerMessageHandler messageHandler)
         {
             builder.Server.AddMessageHandler(messageHandler);
             return builder;

--- a/src/Twino.MQ/NodeManager.cs
+++ b/src/Twino.MQ/NodeManager.cs
@@ -170,8 +170,11 @@ namespace Twino.MQ
             foreach (TmqStickyConnector connector in Connectors)
                 connector.Abort();
 
-            _nodeServer.Stop();
-            _nodeServer = null;
+            if (_nodeServer != null)
+            {
+                _nodeServer.Stop();
+                _nodeServer = null;
+            }
         }
 
         #endregion

--- a/src/Twino.MQ/Twino.MQ.csproj
+++ b/src/Twino.MQ/Twino.MQ.csproj
@@ -6,9 +6,9 @@
         <Product>Twino.MQ</Product>
         <Description>Messaging Queue Server library with TMQ Protocol via Twino Server</Description>
         <PackageTags>twino,server,tmq,messaging,queue,mq</PackageTags>
-        <AssemblyVersion>4.2.0</AssemblyVersion>
-        <FileVersion>4.2.0</FileVersion>
-        <PackageVersion>4.2.0</PackageVersion>
+        <AssemblyVersion>4.2.1</AssemblyVersion>
+        <FileVersion>4.2.1</FileVersion>
+        <PackageVersion>4.2.1</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/twino-framework/twino-mq</PackageProjectUrl>

--- a/src/Twino.Protocols.TMQ/Twino.Protocols.TMQ.csproj
+++ b/src/Twino.Protocols.TMQ/Twino.Protocols.TMQ.csproj
@@ -6,9 +6,9 @@
         <Product>Twino.Protocols.TMQ</Product>
         <Description>Twino Messaging Queue (TMQ) Protocol library and server extension for Twino Server</Description>
         <PackageTags>twino,tcp,server,http,messaging,queue,tmq,mq,protocol</PackageTags>
-        <AssemblyVersion>4.2.0</AssemblyVersion>
-        <FileVersion>4.2.0</FileVersion>
-        <PackageVersion>4.2.0</PackageVersion>
+        <AssemblyVersion>4.2.1</AssemblyVersion>
+        <FileVersion>4.2.1</FileVersion>
+        <PackageVersion>4.2.1</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/twino-framework/twino-mq</PackageProjectUrl>


### PR DESCRIPTION
- Push and Publish Exception attributes now take model type instead of queue or router name. Model type should implement ITransportableException interface.
- Some naming conventions improvements. Old usages are still available with obsolete attribute